### PR TITLE
A few fixes for the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # CASP15_template_gen
-File genrates an sdf style file for a ligand given a smiles or Inchi string as input.
+
+File genrates an sdf style file for a ligand given a smiles or InChI string as input.
 Ligand coordinates are all zeroed and must be added later once predictions are made.
 
 Basic usage:
 
-    template_gen.py -s <SMILES string> 
+    python template_gen.py -s "<SMILES string>"
   
-    will genrate a file named TEMPLATE_<SMILES string>.sdf
+will genrate a file named TEMPLATE_<SMILES string>.sdf
    
-N.b Hydrogens can be removue by setting the -h flag to False.
+Hydrogens can be removed by setting the -h flag to True.
+
+    python template_gen.py -s "<SMILES string>" -h True
+    
 This template can then be used to build CASP LG format files.
 
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Basic usage:
 
     python template_gen.py -s "<SMILES string>"
   
-will genrate a file named TEMPLATE_<SMILES string>.sdf
+will genrate a file named `TEMPLATE_<SMILES string>.sdf`
    
-Hydrogens can be removed by setting the -h flag to True.
+Hydrogens can be removed by setting the `-h` flag to `True`.
 
     python template_gen.py -s "<SMILES string>" -h True
     

--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ Hydrogens can be removed by setting the -h flag to True.
     
 This template can then be used to build CASP LG format files.
 
+## Requirements
+
+- Python 3
+- [RDKit](https://www.rdkit.org/docs/Install.html)
 


### PR DESCRIPTION
I made a few improvements to the README, fixing some typos and:
- Documenting requirements
- Prefixing the command with python and quoting SMILES for safety
- Apparently -h must be True for Hs to be removed.